### PR TITLE
ci: enable build on fork pull request

### DIFF
--- a/.github/workflows/shortify-git-revision.yaml
+++ b/.github/workflows/shortify-git-revision.yaml
@@ -1,5 +1,9 @@
 name: Shortify Git Revision
-on: [push]
+on:
+  push:
+    branches:
+      - v1.x
+  pull_request:
 jobs:
   os-testing:
     strategy:


### PR DESCRIPTION
So external contributors can run the test suite after approval.